### PR TITLE
doc: update jp setup manual

### DIFF
--- a/docs/jp/draft/4.マニュアル類/02_使用手順.txt
+++ b/docs/jp/draft/4.マニュアル類/02_使用手順.txt
@@ -91,9 +91,6 @@ SPP-VMマシン   ： SPP-HOSTマシン上で起動されるSPPと接続するVM
 	# vhostと接続するIFをUP（およびIPアドレスを設定）
 	sudo ifconfig IF名 inet IPアドレス netmask ネットマスク up
 
-	# 対向マシンのIPアドレス／MACアドレスをARPテーブルに登録
-	sudo arp -s 対向マシンIPアドレス 対向マシンMACアドレス -i IF名
-
 	# vhostと接続するIFのオフロード機能をOFF
 	sudo ethtool -K IF名 tx off
 
@@ -101,9 +98,6 @@ SPP-VMマシン   ： SPP-HOSTマシン上で起動されるSPPと接続するVM
 ================================================================================
 ■対向マシン設定  ＠対向マシン
 ================================================================================
-
-	# SPP-VMのIPアドレス／MACアドレスをARPテーブルに登録
-	sudo arp -s SPP-VM_IPアドレス SPP-VM_MACアドレス -i IF名
 
 	# SPP-VMと通信するIFのオフロード機能をOFF
 	ethtool -K IF名 tx off

--- a/docs/spp_vf/spp_vf.md
+++ b/docs/spp_vf/spp_vf.md
@@ -46,47 +46,47 @@ of the application.
 spp_config_load_file() is defined in spp_config.c and default file
 path SPP_CONFIG_FILE_PATH is defined in its header file..
 
-  ```c:spp_vf.c
-	/* set default config file path */
-	strcpy(config_file_path, SPP_CONFIG_FILE_PATH);
+  ```c
+  /* set default config file path */
+  strcpy(config_file_path, SPP_CONFIG_FILE_PATH);
 
-	unsigned int main_lcore_id = 0xffffffff;
-	while(1) {
-		/* Parse dpdk parameters */
-		int ret_parse = parse_dpdk_args(argc, argv);
-		if (unlikely(ret_parse != 0)) {
-			break;
-		}
+  unsigned int main_lcore_id = 0xffffffff;
+  while(1) {
+  	/* Parse dpdk parameters */
+  	int ret_parse = parse_dpdk_args(argc, argv);
+  	if (unlikely(ret_parse != 0)) {
+  		break;
+  	}
 
-		/* DPDK initialize */
-		int ret_dpdk = rte_eal_init(argc, argv);
-		if (unlikely(ret_dpdk < 0)) {
-			break;
-		}
+  	/* DPDK initialize */
+  	int ret_dpdk = rte_eal_init(argc, argv);
+  	if (unlikely(ret_dpdk < 0)) {
+  		break;
+  	}
 
-		/* Skip dpdk parameters */
-		argc -= ret_dpdk;
-		argv += ret_dpdk;
+  	/* Skip dpdk parameters */
+  	argc -= ret_dpdk;
+  	argv += ret_dpdk;
 
-		/* Set log level  */
-		rte_log_set_global_level(RTE_LOG_LEVEL);
+  	/* Set log level  */
+  	rte_log_set_global_level(RTE_LOG_LEVEL);
 
-		/* Parse application parameters */
-		ret_parse = parse_app_args(argc, argv);
-		if (unlikely(ret_parse != 0)) {
-			break;
-		}
+  	/* Parse application parameters */
+  	ret_parse = parse_app_args(argc, argv);
+  	if (unlikely(ret_parse != 0)) {
+  		break;
+  	}
 
-		RTE_LOG(INFO, APP, "Load config file(%s)\n", config_file_path);
+  	RTE_LOG(INFO, APP, "Load config file(%s)\n", config_file_path);
 
-		/* Load config */
-		int ret_config = spp_config_load_file(config_file_path, 0, &g_config);
-		if (unlikely(ret_config != 0)) {
-			break;
-		}
+  	/* Load config */
+  	int ret_config = spp_config_load_file(config_file_path, 0, &g_config);
+  	if (unlikely(ret_config != 0)) {
+  		break;
+  	}
 
-		/* Get core id. */
-		main_lcore_id = rte_lcore_id();
+  	/* Get core id. */
+  	main_lcore_id = rte_lcore_id();
   ```
 
 spp_config_load_file() uses [jansson]() for parsing JSON.
@@ -97,22 +97,25 @@ resource assignment of threads are loaded into config of spp.
 
 After importing config, each of threads are launched.
 
-  ```c:spp_vf.c
-		/* Start  thread */
-		unsigned int lcore_id = 0;
-		RTE_LCORE_FOREACH_SLAVE(lcore_id) {
-			if (g_core_info[lcore_id].type == SPP_CONFIG_CLASSIFIER_MAC) {
-				rte_eal_remote_launch(spp_classifier_mac_do,
-						(void *)&g_core_info[lcore_id],
-						lcore_id);
-			} else {
-				rte_eal_remote_launch(spp_forward,
-						(void *)&g_core_info[lcore_id],
-						lcore_id);
-			}
+  ```c
+	/* Start  thread */
+	unsigned int lcore_id = 0;
+	RTE_LCORE_FOREACH_SLAVE(lcore_id) {
+		if (g_core_info[lcore_id].type == SPP_CONFIG_CLASSIFIER_MAC) {
+			rte_eal_remote_launch(spp_classifier_mac_do,
+					(void *)&g_core_info[lcore_id],
+					lcore_id);
+		} else {
+			rte_eal_remote_launch(spp_forward,
+					(void *)&g_core_info[lcore_id],
+					lcore_id);
 		}
+	}
   ```
 
 ### Forwarding
 
+
 ### Packet Cloning
+
+


### PR DESCRIPTION
Remove description for registering ARP in guests and client machines
which is no need for current version.

Signed-off-by: Yasufumi Ogawa <ogawa.yasufumi@lab.ntt.co.jp>